### PR TITLE
Fix access to undefined index preserve-paths

### DIFF
--- a/src/PluginWrapper.php
+++ b/src/PluginWrapper.php
@@ -170,7 +170,7 @@ class PluginWrapper
         $extra = $this->composer->getPackage()->getExtra();
 
         if (!isset($extra['preserve-paths'])) {
-            $paths = $extra['preserve-paths'];
+            $paths = array();
         } elseif (!is_array($extra['preserve-paths']) && !is_object($extra['preserve-paths'])) {
             $paths = array($extra['preserve-paths']);
         } else {


### PR DESCRIPTION
We should not try to access `$extra['preserve-paths']` if it is not set.

In some situations it might occur that there is a composer file used without the extra preserve-paths. In this case it is checked that the index is not set, but afterwards the index is accessed. This leads to an error and composer aborts.